### PR TITLE
Area input splitting fixed

### DIFF
--- a/nordvpn_switch.py
+++ b/nordvpn_switch.py
@@ -217,7 +217,7 @@ def initialize_VPN(stored_settings=0,save=0,area_input=None):
         if input_needed == 2:
             print("\nYou've entered a list of connection options. Checking list...\n")
             try:
-                settings_servers = [area.lower() for area in area_input]
+                settings_servers = area_input.lower().split(',')
                 settings_servers = ",".join(settings_servers)
             except TypeError:
                 raise Exception("I expected a list here. Are you sure you've not entered a string or some other object?\n ")


### PR DESCRIPTION
Previously was trying to use each character in string as an area.  Now, will split on commas.

Please consider merging this minor change.