### PR TITLE
fixed Issue 54- UnicodeEncodeError when running via terminal in windows 

### DIFF
--- a/nordvpn_switch.py
+++ b/nordvpn_switch.py
@@ -7,6 +7,7 @@ from os import path
 import platform
 import subprocess
 from subprocess import check_output,DEVNULL
+import sys
 #2.utilities (randomisations etc)
 import psutil
 import random
@@ -124,6 +125,16 @@ def initialize_VPN(stored_settings=0,save=0,area_input=None,skip_settings=0):
         print("\33[33mYou're using Windows.\n"
               "Performing system check...\n"
               "###########################\n\33[0m")
+                
+        # Check if the platform is Windows
+        if platform.system() == 'Windows':
+            # Change the encoding to 'utf-8' for Windows terminal
+            if sys.version_info >= (3, 7):
+                try:
+                    sys.stdout.reconfigure(encoding='utf-8')
+                except Exception as e:
+                    print(f"An error occurred while reconfiguring stdout: {e}")
+
         #seek and set windows installation path#
         option_1_path = 'C:/Program Files/NordVPN'
         option_2_path = 'C:/Program Files (x86)/NordVPN'


### PR DESCRIPTION
## Description
Fix for [Issue #54 - UnicodeEncodeError when running via terminal in windows](https://github.com/kboghe/NordVPN-switcher/issues/54#issue-2092295708)


## Motivation and Context

When executing a python script via a batch script (.bat) and calling the function initialize_VPN(...) it will throw a UnicodeEncodeError this update will set the encoding to 'utf-8'. However this issue is only fixed for python versions 3.7 and above as the "sys.stdout.reconfigure()" method is available starting from 3.7

## Changes Made
`import sys` [+line 10]

[+lines 129-136]
```
# Check if the platform is Windows
if platform.system() == 'Windows':
    # Change the encoding to 'utf-8' for Windows terminal
    if sys.version_info >= (3, 7):
        try:
            sys.stdout.reconfigure(encoding='utf-8')
        except Exception as e:
            print(f"An error occurred while reconfiguring stdout: {e}")
```